### PR TITLE
Bug Fix: Use WordPress functions for retrieving the response

### DIFF
--- a/gravity-forms-no-captcha-recaptcha/trunk/public/class-gf-no-captcha-recaptcha-public.php
+++ b/gravity-forms-no-captcha-recaptcha/trunk/public/class-gf-no-captcha-recaptcha-public.php
@@ -290,7 +290,8 @@ class GFNoCaptchaReCaptcha_Public {
                 $recaptcha_response = urlencode( $_POST['g-recaptcha-response'] );
                 $user_ip            = $_SERVER['REMOTE_ADDR'];
                 $verify_url         = $this->sanitize_url( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $this->google_private_key . '&response=' . $recaptcha_response . '&remoteip=' . $user_ip );
-                $json_response      = file_get_contents( $verify_url );
+                $request = wp_remote_get($verify_url);
+                $json_response = wp_remote_retrieve_body( $request );
 
                 if( ! empty( $json_response ) && $result = json_decode( $json_response, true ) ) {
 


### PR DESCRIPTION
https://wordpress.org/support/topic/captcha-failed-please-try-again and other support topics have this as an issue, and myself is included in that.

**Bug:** I had set this site on a development site, but then this captcha broke (would always show it failed even though it was passing on the client's end) after the site was moved. As an aside, it seems this is an issue if the site is behind a proxy as well.

**Fix:** It seems simply switching from file_get_contents to wp_remote_get and wp_remote_retrieve_body fixes this issue.

I'd love to see this implemented in the public version.