### PR TITLE
Add locale support with filter and Polylang

### DIFF
--- a/gravity-forms-no-captcha-recaptcha/trunk/public/class-gf-no-captcha-recaptcha-public.php
+++ b/gravity-forms-no-captcha-recaptcha/trunk/public/class-gf-no-captcha-recaptcha-public.php
@@ -252,8 +252,22 @@ class GFNoCaptchaReCaptcha_Public {
 
 				if ( ( $field['type'] == $this->gravity_forms_field_type ) && ! empty( $this->google_public_key ) ) {
 
+					$locale = '';
+
+					// get site's language if polylang is active
+					if( function_exists( 'pll_current_language' ) ) {
+						$locale = pll_current_language();
+					}
+
+					// let plugins and themes do their own language logic
+					$locale = apply_filters( 'gravity_forms_recaptcha_locale', $locale );
+
+					if( !empty( $locale ) ) {
+						$locale = '&hl=' . esc_attr( $locale );
+					}
+
 					// Enqueue External API JS
-					wp_enqueue_script( 'no_captcha_recaptcha_api', 'https://www.google.com/recaptcha/api.js?render=explicit', array(), '', true );
+					wp_enqueue_script( 'no_captcha_recaptcha_api', 'https://www.google.com/recaptcha/api.js?render=explicit' . $locale, array(), '', true );
 
 					// Enqueue Internal JS (renders CAPTCHA explicitly - maintains AJAX submission compatibility)
 					wp_enqueue_script( 'no_captcha_recaptcha_internal', plugin_dir_url( __FILE__ ) . 'js/gf-no-captcha-recaptcha-public.js', array(


### PR DESCRIPTION
Google's reCAPTCHA supports different locales that can be defined as $_GET variables in api.js asset url. By default reCAPTCHA changes the language according to user's browser but that's not good enough as user's browser and OS can often be different language (like English) that their first language.

That's why the plugin should support defining the language, too. The tricky part comes from available locales as they are not always same as WordPress locales. That's why I wouldn't use `get_locale` here.

I added support for Polylang that uses standard two-character locales which is most of the time accurate enough but also a filter that let's plugins and themes use custom logic. If no locale is defined, the language will work just as it has before.