### PR TITLE
added nocaptcha class to field rendering

### DIFF
--- a/gravity-forms-no-captcha-recaptcha/trunk/public/class-gf-no-captcha-recaptcha-public.php
+++ b/gravity-forms-no-captcha-recaptcha/trunk/public/class-gf-no-captcha-recaptcha-public.php
@@ -188,7 +188,7 @@ class GFNoCaptchaReCaptcha_Public {
                     'normal';
 
                 // Public sees CAPTCHA field
-                return '<div class="ginput_container"><div class="g-recaptcha" data-sitekey="' . $site_key . '" data-theme="' . $theme . '" data-size="' . $theme_size . '"></div></div>';
+                return '<div class="ginput_container nocaptcha"><div class="g-recaptcha" data-sitekey="' . $site_key . '" data-theme="' . $theme . '" data-size="' . $theme_size . '"></div></div>';
 
             } else {
 


### PR DESCRIPTION
ginput_container now has additional class 'nocaptcha'  

It is usefull for example for styling error messages specifically for this field in a way like
` .nocaptcha + .validation_message { 
    /* Styles for error / validation message  only for recaptcha */ 
 }  ` 